### PR TITLE
Create public_repository_request.md

### DIFF
--- a/PULL_REQUEST_TEMPLATE/public_repository_request.md
+++ b/PULL_REQUEST_TEMPLATE/public_repository_request.md
@@ -41,7 +41,7 @@ Use the checklist below to track your progress on these items. Add to the checkl
 ## Repository requirements
 
 1.	The repository must be clean
-	  - No absolute paths; all paths must be relative to project root directory
+	- No absolute paths; all paths must be relative to project root directory
     - No API keys, passwords, credentials, or other “secrets” in plain text. 
     - Scan for secrets with [Talisman](https://thoughtworks.github.io/talisman/) and remove secrets
     - If secrets exist in the git history, consider using a tool like [BFG Repo-Cleaner](https://rtyley.github.io/bfg-repo-cleaner/) or create a new repository and copy/paste all materials (excluding .git/)
@@ -52,10 +52,10 @@ Use the checklist below to track your progress on these items. Add to the checkl
       - !.gitignore
     - All code should be documented, at a minimum describing what the code does, and a description of parameters, returned values and side-effects.
 1.	The code must have an approved OSS license, e.g., MIT, Apache-2.0, BSD-3, with the Metropolitan Council as the license holder.
-	  - Data or documentation repositories should have an appropriate data license, e.g., PDDL-10, CC0-1.0, CC-BY-4.0.
+	- Data or documentation repositories should have an appropriate data license, e.g., PDDL-10, CC0-1.0, CC-BY-4.0.
     - Public domain dedications (CC0, PDDL) relinquish all rights and are usual what we intend when we publish data, but you may find it appropriate in some conditions to maintain copyright and requesting minimal attribution.
     - If a license other than MIT or Apache 2.0 is used, describe why in the request. 
- - Approved licenses are defined in Tech 3-4: Code and Data Licensing Policy
+    - Approved licenses are defined in Tech 3-4: Code and Data Licensing Policy
 1.	A README.md file describes the purpose of the project
 1.	Add appropriate branch protection to the main branch
 

--- a/PULL_REQUEST_TEMPLATE/public_repository_request.md
+++ b/PULL_REQUEST_TEMPLATE/public_repository_request.md
@@ -8,21 +8,23 @@ Please answer the questions in **bold** with sufficient detail. All sections mus
 
 ### Describe the need for making it public
 
-**Describe security risks to the Council if malicious code were injected into the repo (worst case scenario)**
+<!-- Is this code to be shared with external collaborators? -->
 
 ### Describe security risks to the Council if malicious code were injected into the repo (worst case scenario)
 
 ### Does the repository contain only documentation or example code?
 
-**Is the code for a mission critical application?**
+<!-- Are all the public functions fully documented?-->
 
 ### Do we use the code internally?
 
-Use the checklist below to track your progress on these items. Add to the checklist if you complete additional steps
+<!-- Is the code used in any automated processes onsite? -->
 ### Is the code for a mission critical application?
 
 ### Describe precautions taken to mitigate risk
+<!--Pull-request review process, automated or manual testing procedures, access and push restrictions. Use checklist.-->
 ### Describe expected level of outside interaction 
+<!-- Popularity, issues, pull-requests from general public or potential collaborators -->
 ### Checklist 
 - [ ] Primary repository branch is named "main"
 - [ ] Branch "main" protected

--- a/PULL_REQUEST_TEMPLATE/public_repository_request.md
+++ b/PULL_REQUEST_TEMPLATE/public_repository_request.md
@@ -4,22 +4,26 @@
 
 Please answer the questions in **bold** with sufficient detail. All sections must be filled out. 
 
-**Describe the purpose of the code**
+### Describe the purpose of the code
 
-**Describe the need for making it public** 
+### Describe the need for making it public
 
 **Describe security risks to the Council if malicious code were injected into the repo (worst case scenario)**
 
-**Does the repository contain only documentation or example code?**
+### Describe security risks to the Council if malicious code were injected into the repo (worst case scenario)
 
-**Do we use the code internally?** 
+### Does the repository contain only documentation or example code?
 
 **Is the code for a mission critical application?**
 
-**Describe precautions taken to mitigate risk (pull-request review, testing, & etc.)**
+### Do we use the code internally?
 
 Use the checklist below to track your progress on these items. Add to the checklist if you complete additional steps
+### Is the code for a mission critical application?
 
+### Describe precautions taken to mitigate risk
+### Describe expected level of outside interaction 
+### Checklist 
 - [ ] Primary repository branch is named "main"
 - [ ] Branch "main" protected
 - [ ] Only specifically noted users (tag users using @) have push privileges to repo on any branch
@@ -36,7 +40,6 @@ Use the checklist below to track your progress on these items. Add to the checkl
 
 *optional 
 
-**Describe expected level of outside interaction (popularity, issues, pull-requests)**
 
 ## Repository requirements
 

--- a/PULL_REQUEST_TEMPLATE/public_repository_request.md
+++ b/PULL_REQUEST_TEMPLATE/public_repository_request.md
@@ -76,11 +76,12 @@ Use the checklist below to track your progress on these items, particularly thos
 1.	A README.md file describes the purpose of the project
 1.	Add appropriate branch protection to the main branch
 
-## Manager approval
+## Steps to approval
 
-If organizational risk is considered low, no further approval required. Otherwise, forward this request as an email to IS security via the ServiceDesk.
+- [ ] If organizational risk is **not** considered low, forward this request as an email to IS security via the ServiceDesk.
+- [ ] Your manager must approve this pull-request. If they are on GitHub, [request a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from them. If your manager is not on GitHub, they can approve by sending an email to a repo admin, who can then add the contents of the email to the pull-request and approve on their behalf. 
+- [ ] Once approved, request a GitHub admin make the repo public. 
 
 (tag manager with @), we request your review on this repository. If you approve making this repository public, please approve the pull-request.
 
-Once approved the Metropolitan-Council GitHub organization admin or other Council employee with the appropriate GitHub role will change the repository visibility to "Public".
 

--- a/PULL_REQUEST_TEMPLATE/public_repository_request.md
+++ b/PULL_REQUEST_TEMPLATE/public_repository_request.md
@@ -2,7 +2,7 @@
 
 ## Request details
 
-Please answer the questions in **bold** with sufficient detail. All sections must be filled out. 
+Please answer the following questions with sufficient detail. All sections must be filled out. 
 
 ### Describe the purpose of the code
 
@@ -19,13 +19,22 @@ Please answer the questions in **bold** with sufficient detail. All sections mus
 ### Do we use the code internally?
 
 <!-- Is the code used in any automated processes onsite? -->
+
 ### Is the code for a mission critical application?
 
+
 ### Describe precautions taken to mitigate risk
+
 <!--Pull-request review process, automated or manual testing procedures, access and push restrictions. Use checklist.-->
+
 ### Describe expected level of outside interaction 
+
 <!-- Popularity, issues, pull-requests from general public or potential collaborators -->
+
 ### Checklist 
+
+Use the checklist below to track your progress on these items, particularly those that have to be done manually through GitHub. Add to the checklist if you complete additional steps
+
 - [ ] Primary repository branch is named "main"
 - [ ] Branch "main" protected
 - [ ] Only specifically noted users (tag users using @) have push privileges to repo on any branch
@@ -51,10 +60,12 @@ Please answer the questions in **bold** with sufficient detail. All sections mus
     - Scan for secrets with [Talisman](https://thoughtworks.github.io/talisman/) and remove secrets
     - If secrets exist in the git history, consider using a tool like [BFG Repo-Cleaner](https://rtyley.github.io/bfg-repo-cleaner/) or create a new repository and copy/paste all materials (excluding .git/)
 1.	The code must meet professional standards
-    - All commit messages, code comments and other documentation are professional and informative.
-    - A .gitignore file is required, and should at a minimum contain:
-      - .*
-      - !.gitignore
+    - All commit messages, code comments and other documentation are professional and informative. If there are substandard commit messages in the git history, consider creating a new repository and copy/pasting all materials (exlcuding .git/).
+    - A .gitignore file is required, and should at a minimum contain
+        ```gitignore
+            .*
+            !.gitignore
+        ```
     - All code should be documented, at a minimum describing what the code does, and a description of parameters, returned values and side-effects.
 1.	The code must have an approved OSS license, e.g., MIT, Apache-2.0, BSD-3, with the Metropolitan Council as the license holder.
 	- Data or documentation repositories should have an appropriate data license, e.g., PDDL-10, CC0-1.0, CC-BY-4.0.

--- a/PULL_REQUEST_TEMPLATE/public_repository_request.md
+++ b/PULL_REQUEST_TEMPLATE/public_repository_request.md
@@ -82,6 +82,6 @@ Use the checklist below to track your progress on these items, particularly thos
 - [ ] Your manager must approve this pull-request. If they are on GitHub, [request a review](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review) from them. If your manager is not on GitHub, they can approve by sending an email to a repo admin, who can then add the contents of the email to the pull-request and approve on their behalf. 
 - [ ] Once approved, request a GitHub admin make the repo public. 
 
-(tag manager with @), we request your review on this repository. If you approve making this repository public, please approve the pull-request.
+The repo administrator and maintainer are responsible for ensuring that the repo requirements are upheld as development continues. Review these requirements with all current and new collaborators. 
 
 

--- a/PULL_REQUEST_TEMPLATE/public_repository_request.md
+++ b/PULL_REQUEST_TEMPLATE/public_repository_request.md
@@ -36,18 +36,18 @@ Please answer the following questions with sufficient detail. All sections must 
 Use the checklist below to track your progress on these items, particularly those that have to be done manually through GitHub. Add to the checklist if you complete additional steps
 
 - [ ] Primary repository branch is named "main"
-- [ ] Branch "main" protected
-- [ ] Only specifically noted users (tag users using @) have push privileges to repo on any branch
-- [ ] Pull request required before merging to "main"
+- [ ] Branch "main" [protected](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches).
+- [ ] Only specifically noted users (tag users using @) have [push privileges](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/managing-repository-settings/managing-teams-and-people-with-access-to-your-repository) on any branch
+- [ ] Pull-request required before merging to "main"
 - [ ] At least one approval needed from maintainers (tag maintainers using @) before pull-requst merge
 - [ ] Conversations and change requests must be resolved before pull-request merge
-- [ ] Comprehensive README included [README.MD](README.MD)
+- [ ] Comprehensive README included [README.MD](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-readmes)
 - [ ] Repository content reviewed for typos, grammar, and other inconsistencies
 - [ ] Repository git history is clean: no sensitive data commited and later removed from repository
 - [ ] *Contributing or style guide included [CONTRIBUTING.MD](CONTRIBUTING.MD)
-- [ ] *Pull request template included [PULL_REQUEST_TEMPLATE.MD](.github/PULL_REQUEST_TEMPLATE.MD)
+- [ ] *Issue and pull-request templates included. See GitHub [documentation](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates) for more detais. 
 - [ ] *Code of conduct included [CODE_OF_CONDUCT.MD](CODE_OF_CONDUCT.MD)
-- [ ] *Automated testing (describe)
+- [ ] *Automated testing with GitHub Actions or other CI/CD tool (describe)
 
 *optional 
 
@@ -58,7 +58,7 @@ Use the checklist below to track your progress on these items, particularly thos
 	- No absolute paths; all paths must be relative to project root directory
     - No API keys, passwords, credentials, or other “secrets” in plain text. 
     - Scan for secrets with [Talisman](https://thoughtworks.github.io/talisman/) and remove secrets
-    - If secrets exist in the git history, consider using a tool like [BFG Repo-Cleaner](https://rtyley.github.io/bfg-repo-cleaner/) or create a new repository and copy/paste all materials (excluding .git/)
+    - If secrets exist in the git history, consider using a tool like [BFG Repo-Cleaner](https://rtyley.github.io/bfg-repo-cleaner/) or create a new repository and copy/paste all materials (excluding .git/).
 1.	The code must meet professional standards
     - All commit messages, code comments and other documentation are professional and informative. If there are substandard commit messages in the git history, consider creating a new repository and copy/pasting all materials (exlcuding .git/).
     - A .gitignore file is required, and should at a minimum contain
@@ -67,11 +67,11 @@ Use the checklist below to track your progress on these items, particularly thos
             !.gitignore
         ```
     - All code should be documented, at a minimum describing what the code does, and a description of parameters, returned values and side-effects.
-1.	The code must have an approved OSS license, e.g., MIT, Apache-2.0, BSD-3, with the Metropolitan Council as the license holder.
-	- Data or documentation repositories should have an appropriate data license, e.g., PDDL-10, CC0-1.0, CC-BY-4.0.
-    - Public domain dedications (CC0, PDDL) relinquish all rights and are usual what we intend when we publish data, but you may find it appropriate in some conditions to maintain copyright and requesting minimal attribution.
+1.	The code must have an approved OSS license, e.g., [MIT](https://spdx.org/licenses/MIT.html), [Apache-2.0](https://www.apache.org/licenses/LICENSE-2.0), [BSD-3](https://spdx.org/licenses/BSD-3-Clause.html), with the Metropolitan Council as the license holder.
+	- Data or documentation repositories should have an appropriate data license, e.g., [PDDL-1.0](https://opendatacommons.org/licenses/pddl/1-0/), [CC0-1.0](https://creativecommons.org/publicdomain/zero/1.0/), [CC-BY-4.0](https://creativecommons.org/licenses/by/4.0/).
+    - Public domain dedications (CC0, PDDL) relinquish all rights and are usually what we intend when we publish data, but you may find it appropriate in some conditions to maintain copyright and requesting minimal attribution.
     - License should have a [Blue Oak Council](https://blueoakcouncil.org/list) rating of Gold, Silver, or Bronze.
-    - If a license other than MIT or Apache 2.0 is used, describe why in the request. 
+    - If a license other than MIT, Apache 2.0, or BSD-3 is used, describe why in the request. 
 1.	A README.md file describes the purpose of the project
 1.	Add appropriate branch protection to the main branch
 

--- a/PULL_REQUEST_TEMPLATE/public_repository_request.md
+++ b/PULL_REQUEST_TEMPLATE/public_repository_request.md
@@ -54,8 +54,8 @@ Use the checklist below to track your progress on these items. Add to the checkl
 1.	The code must have an approved OSS license, e.g., MIT, Apache-2.0, BSD-3, with the Metropolitan Council as the license holder.
 	- Data or documentation repositories should have an appropriate data license, e.g., PDDL-10, CC0-1.0, CC-BY-4.0.
     - Public domain dedications (CC0, PDDL) relinquish all rights and are usual what we intend when we publish data, but you may find it appropriate in some conditions to maintain copyright and requesting minimal attribution.
+    - License should have a [Blue Oak Council](https://blueoakcouncil.org/list) rating of Gold, Silver, or Bronze.
     - If a license other than MIT or Apache 2.0 is used, describe why in the request. 
-    - Approved licenses are defined in Tech 3-4: Code and Data Licensing Policy
 1.	A README.md file describes the purpose of the project
 1.	Add appropriate branch protection to the main branch
 

--- a/PULL_REQUEST_TEMPLATE/public_repository_request.md
+++ b/PULL_REQUEST_TEMPLATE/public_repository_request.md
@@ -72,6 +72,7 @@ Use the checklist below to track your progress on these items, particularly thos
     - Public domain dedications (CC0, PDDL) relinquish all rights and are usually what we intend when we publish data, but you may find it appropriate in some conditions to maintain copyright and requesting minimal attribution.
     - License should have a [Blue Oak Council](https://blueoakcouncil.org/list) rating of Gold, Silver, or Bronze.
     - If a license other than MIT, Apache 2.0, or BSD-3 is used, describe why in the request. 
+    - If a license holder other than the Metropolitan Council is listed, explain why and reference any relevant contracts or agreements. 
 1.	A README.md file describes the purpose of the project
 1.	Add appropriate branch protection to the main branch
 

--- a/PULL_REQUEST_TEMPLATE/public_repository_request.md
+++ b/PULL_REQUEST_TEMPLATE/public_repository_request.md
@@ -1,0 +1,69 @@
+# Repository visibility change request - private/internal to public
+
+## Request details
+
+Please answer the questions in **bold** with sufficient detail. All sections must be filled out. 
+
+**Describe the purpose of the code**
+
+**Describe the need for making it public** 
+
+**Describe security risks to the Council if malicious code were injected into the repo (worst case scenario)**
+
+**Does the repository contain only documentation or example code?**
+
+**Do we use the code internally?** 
+
+**Is the code for a mission critical application?**
+
+**Describe precautions taken to mitigate risk (pull-request review, testing, & etc.)**
+
+Use the checklist below to track your progress on these items. Add to the checklist if you complete additional steps
+
+- [ ] Primary repository branch is named "main"
+- [ ] Branch "main" protected
+- [ ] Only specifically noted users (tag users using @) have push privileges to repo on any branch
+- [ ] Pull request required before merging to "main"
+- [ ] At least one approval needed from maintainers (tag maintainers using @) before pull-requst merge
+- [ ] Conversations and change requests must be resolved before pull-request merge
+- [ ] Comprehensive README included [README.MD](README.MD)
+- [ ] Repository content reviewed for typos, grammar, and other inconsistencies
+- [ ] Repository git history is clean: no sensitive data commited and later removed from repository
+- [ ] *Contributing or style guide included [CONTRIBUTING.MD](CONTRIBUTING.MD)
+- [ ] *Pull request template included [PULL_REQUEST_TEMPLATE.MD](.github/PULL_REQUEST_TEMPLATE.MD)
+- [ ] *Code of conduct included [CODE_OF_CONDUCT.MD](CODE_OF_CONDUCT.MD)
+- [ ] *Automated testing (describe)
+
+*optional 
+
+**Describe expected level of outside interaction (popularity, issues, pull-requests)**
+
+## Repository requirements
+
+1.	The repository must be clean
+	  - No absolute paths; all paths must be relative to project root directory
+    - No API keys, passwords, credentials, or other “secrets” in plain text. 
+    - Scan for secrets with [Talisman](https://thoughtworks.github.io/talisman/) and remove secrets
+    - If secrets exist in the git history, consider using a tool like [BFG Repo-Cleaner](https://rtyley.github.io/bfg-repo-cleaner/) or create a new repository and copy/paste all materials (excluding .git/)
+1.	The code must meet professional standards
+    - All commit messages, code comments and other documentation are professional and informative.
+    - A .gitignore file is required, and should at a minimum contain:
+      - .*
+      - !.gitignore
+    - All code should be documented, at a minimum describing what the code does, and a description of parameters, returned values and side-effects.
+1.	The code must have an approved OSS license, e.g., MIT, Apache-2.0, BSD-3, with the Metropolitan Council as the license holder.
+	  - Data or documentation repositories should have an appropriate data license, e.g., PDDL-10, CC0-1.0, CC-BY-4.0.
+    - Public domain dedications (CC0, PDDL) relinquish all rights and are usual what we intend when we publish data, but you may find it appropriate in some conditions to maintain copyright and requesting minimal attribution.
+    - If a license other than MIT or Apache 2.0 is used, describe why in the request. 
+ - Approved licenses are defined in Tech 3-4: Code and Data Licensing Policy
+1.	A README.md file describes the purpose of the project
+1.	Add appropriate branch protection to the main branch
+
+## Manager approval
+
+If organizational risk is considered low, no further approval required. Otherwise, forward this request as an email to IS security via the ServiceDesk.
+
+(tag manager with @), we request your review on this repository. If you approve making this repository public, please approve the pull-request.
+
+Once approved the Metropolitan-Council GitHub organization admin or other Council employee with the appropriate GitHub role will change the repository visibility to "Public".
+

--- a/PULL_REQUEST_TEMPLATE/public_repository_request.md
+++ b/PULL_REQUEST_TEMPLATE/public_repository_request.md
@@ -6,30 +6,42 @@ Please answer the following questions with sufficient detail. All sections must 
 
 ### Describe the purpose of the code
 
+<!-- A few sentences are sufficient. -->
+
 ### Describe the need for making it public
 
 <!-- Is this code to be shared with external collaborators? -->
 
 ### Describe security risks to the Council if malicious code were injected into the repo (worst case scenario)
 
+<!-- Does the code write/save data outside the repository?
+Does the code work with private or non-public data?
+Are there ways your code could leak sensitive data or credentials, or give an attacker access to systems? -->
+
 ### Does the repository contain only documentation or example code?
 
-<!-- Are all the public functions fully documented?-->
+<!-- Are all the public functions fully documented?
+If the repository is mostly functions for working on a specific problem, should it be a package? Should it be published to a public package repository (e.g., CRAN, r-universe, PyPi)? -->
 
 ### Do we use the code internally?
 
-<!-- Is the code used in any automated processes onsite? -->
+<!-- Is the code used in any automated processes? -->
 
 ### Is the code for a mission critical application?
 
+<!-- If yes, describe application and potential risks. -->
 
 ### Describe precautions taken to mitigate risk
 
-<!--Pull-request review process, automated or manual testing procedures, access and push restrictions. Use checklist.-->
+<!-- How are credentials managed and what steps are taken to ensure they aren't committed to the repo in the future? 
+If you're using GitHub Actions or another CI/CD tool, are you following best practices for pull-requests from forks to prevent leaks of credentials?
+Describe pull-request review process, automated or manual testing procedures, access and push restrictions. Use checklist below. -->
 
 ### Describe expected level of outside interaction 
 
-<!-- Popularity, issues, pull-requests from general public or potential collaborators -->
+<!-- What is the expected repo popularity? 
+How many Issues do you anticipate will be submitted? What is your process for managing them? 
+Are you expecting Issues and pull-requests from the general public? -->
 
 ### Checklist 
 


### PR DESCRIPTION
This PR creates a single pull request template for Council use. This is based off previous internal facing documents and PRs for existing public repos like [streetlightR](https://github.com/Metropolitan-Council/streetlightR), [covid-poops](https://github.com/Metropolitan-Council/covid-poops), and [metc.tbi.helper](https://github.com/Metropolitan-Council/metc.tbi.helper). 

The template guides the user through the requirements and considerations for changing a repository's visibility to public (making a repo public). 

Features include

- Instructions for requesting a public repo
- Standard request details for the user to fill out
- A checklist for repo settings
-  Acceptable license examples and a link to the Blue Oak Council ratings
- Suggestions for repository health measures, such as Talisman and BFG repo cleaner
